### PR TITLE
Update image_conversion.py

### DIFF
--- a/falconz/image_conversion.py
+++ b/falconz/image_conversion.py
@@ -97,7 +97,7 @@ class NiftiConverter:
             os.remove(os.path.join(self.output_directory, json_file[0]))
 
         # Scan the output directory for the generated nifti files
-        converted_files = [f for f in os.listdir(self.output_directory) if f.endswith('.nii.gz')]
+        converted_files = [f for f in os.listdir(self.output_directory) if (f.endswith('.nii.gz') or f.endswith('.nii'))]
 
         for nifti_file in converted_files:
             file_path = os.path.join(self.output_directory, nifti_file)


### PR DESCRIPTION
Fixed a bug where the converted nifti file wasn't found when it was too big for `pigz` to compress. This caused the subsequent steps of `falconz` to fail. The search includes `.nii` as well (it was only `.nii.gz` before)